### PR TITLE
use include_tasks instead if deprecated include

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -1,13 +1,13 @@
 ---
 
-- include: install.yml
+- include_tasks: install.yml
   tags:
     - system
     - swap
     - install
     - swap-install
 
-- include: config.yml
+- include_tasks: config.yml
   tags:
     - system
     - swap


### PR DESCRIPTION
`include` has been deprecated by ansible version 2.16.
```
"include" is deprecated, use include_tasks/import_tasks instead. This feature will be removed in version 2.16.
```

Replacing it `with include_tasks` worked for me.
